### PR TITLE
Updated based on audit recommendations

### DIFF
--- a/contracts/TransmuteAgent.sol
+++ b/contracts/TransmuteAgent.sol
@@ -34,6 +34,14 @@ contract TransmuteAgent is Ownable {
         return token.allowance(msg.sender, address(this)); 
     }
 
+    function() {
+        revert(); 
+    }
+
+    function TransmuteAgent(BurnableToken _token) {
+        token = _token;
+    }
+  
     /**
     * Cross-chain transmution burns the original
     * HLTH token. 
@@ -68,12 +76,12 @@ contract TransmuteAgent is Ownable {
 
     /**
     * [Admin Only]
-    * enable/disable 
+    * enable / disable 
     */
-    function enable(bool _enabled) 
-    onlyOwner 
-    {
-        enabled = _enabled;
+    function enable() onlyOwner {
+        enabled = true;
     }
-
+    function disable() onlyOwner {
+        enabled = false;
+    }
 }

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -1,5 +1,5 @@
 var transmute = artifacts.require("./TransmuteAgent.sol")
 
 module.exports = function(deployer) {
-    deployer.deploy(transmute)    
+    deployer.deploy(transmute, '0x0')    
 };

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -1,5 +1,6 @@
 var transmute = artifacts.require("./TransmuteAgent.sol")
+var hlth_token_address = '0x0' //update before deploy
 
 module.exports = function(deployer) {
-    deployer.deploy(transmute, '0x0')    
+    deployer.deploy(transmute, hlth_token_address)    
 };

--- a/test/TransmuteAgent.js
+++ b/test/TransmuteAgent.js
@@ -12,11 +12,21 @@ contract('TransmuteAgent', function(accounts) {
 
   beforeEach(async function() {
     this.token = await HealthCashMock.new()
-    this.agent = await TransmuteAgent.new()
-    await this.agent.setTokenToTransmute(this.token.address)
+    this.agent = await TransmuteAgent.new(this.token.address)
   })
 
   it('should not allow transmutation until enabled', async function() {
+    let validAddress = accounts[1]
+    await this.agent.transmuteToken(validAddress, 10)
+    let totalSupply = await this.token.totalSupply()    
+    totalSupply.should.be.bignumber.equal(100)
+  })
+
+  it('should not allow transmutation after disabled', async function() {
+    await this.token.approve(this.agent.address, 10);    
+    await this.agent.enable()
+    await this.agent.disable()
+
     let validAddress = accounts[1]
     await this.agent.transmuteToken(validAddress, 10)
     let totalSupply = await this.token.totalSupply()    
@@ -27,7 +37,7 @@ contract('TransmuteAgent', function(accounts) {
     
     //Tranmutation Agent must be explictly approved
     await this.token.approve(this.agent.address, 10);    
-    await this.agent.enable(true) 
+    await this.agent.enable() 
 
     let validAddress = accounts[0]
     await this.agent.transmuteToken(validAddress, 10)
@@ -40,7 +50,7 @@ contract('TransmuteAgent', function(accounts) {
 
     //Tranmutation Agent must be explictly approved
     await this.token.approve(this.agent.address, 10);
-    await this.agent.enable(true)    
+    await this.agent.enable()    
 
     let validAddress = accounts[0]
     await this.agent.transmuteToken(validAddress,10)
@@ -51,7 +61,7 @@ contract('TransmuteAgent', function(accounts) {
   it('should be unable to transmute too many tokens', async function() {
     //Tranmutation Agent must be explictly approved
     await this.token.approve(this.agent.address, 100);
-    await this.agent.enable(true)    
+    await this.agent.enable()    
     await this.agent.transmuteToken(accounts[0],900)
     
     let balance = await this.token.balanceOf(accounts[0])
@@ -62,7 +72,7 @@ contract('TransmuteAgent', function(accounts) {
   })
 
   it('should be unable to transmute from an account without authorization', async function() {
-    await this.agent.enable(true)    
+    await this.agent.enable()    
     await this.agent.transmuteToken(accounts[0],100)
     let balance = await this.token.balanceOf(accounts[0])
     balance.should.be.bignumber.equal(100,'was able to transfer unauthorized tokens')
@@ -72,7 +82,7 @@ contract('TransmuteAgent', function(accounts) {
   it('should increment the Trasmute Agent Nonce', async function() {
     
     await this.token.approve(this.agent.address, 2);        
-    await this.agent.enable(true)  
+    await this.agent.enable()  
     let validAddress = accounts[1]
 
     await this.agent.transmuteToken(validAddress,1)
@@ -87,7 +97,7 @@ contract('TransmuteAgent', function(accounts) {
 
   it('should create a valid Transmute Event', async function() {
     await this.token.approve(this.agent.address, 10);        
-    await this.agent.enable(true)  
+    await this.agent.enable()  
     let validAddress = accounts[1]
     let tx = await this.agent.transmuteToken(validAddress, 10)
 


### PR DESCRIPTION
File:​ ​ TransmuteAgent.sol
L34:​ ​ There​ ​ should​ ​ likely​ ​ be​ ​ a ​ ​ check​ ​ that​ ​ token​ ​ is​ ​ insantiated​ ​ before​ ​ calling​ ​ the​ ​ allowance
Function

**SVH: Constructor added requiring BurnableToken.** 

L41:​ ​ What​ ​ does​ ​ the​ ​ _to​ ​ value​ ​ do​ ​ in​ ​ transmuteToken?​ ​ Is​ ​ it​ ​ redundant​ ​ with​ ​ the​ ​ event​ ​ Transmute?

**SVH: The _to address is the destination address on the Health Nexus blockchain where he health cash will be delivered. Health Nexus is a fork of Ethereum the addresses are compatible.** 


L73:​ ​ For​ ​ clarity/style,​ ​ the​ ​ function​ ​ enable​ ​ should​ ​ have​ ​ a ​ ​ corresponding​ ​ disable​ ​ function​ ​ rather than​ ​ doing​ ​ both.

**SVH: refactored this into both enable and disable functions**
